### PR TITLE
tasks / main.yaml - add koff

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,6 +21,13 @@
     - sudo mv omc_Linux_x86_64 /usr/bin/omc
     - chmod +x /usr/bin/omc
 
+- name: Download the koff tool
+  ansible.builtin.command: "{{ item }}"
+  loop:
+    - wget https://github.com/gmeghnag/koff/releases/download/v1.0.1/koff_Linux_x86_64
+    - sudo mv koff_Linux_x86_64 /usr/bin/koff
+    - chmod +x /usr/bin/koff
+
 - name: Download the oc tool
   ansible.builtin.command: "{{ item }}"
   loop:


### PR DESCRIPTION
`koff` tool, from the same author of `omc`.

It can be used to run `koff get <resource>` directly from a _etcd_ db backup.
It might be shown as alternative of checking the number of resources on _etcd_ if a _mustgather_ is broken.